### PR TITLE
Error in ComBat function call

### DIFF
--- a/Coincide_fullPackage/Coincide/R/CoINcIDE_batchCorrection.R
+++ b/Coincide_fullPackage/Coincide/R/CoINcIDE_batchCorrection.R
@@ -100,7 +100,7 @@ BatchCorrection <- function(GEN_Data,BatchData,mod,batchColName,outputFile="./co
   
   #par.prior=TRUE indicates parametric adjustments will be used
   #need a numeric batch variable.
-  CombatResults <- ComBat(dat=GEN_Data, batch=BatchDataSelected[,batchColName], mod=mod, par.prior=TRUE, prior.plots=FALSE,numCovs=NULL);
+  CombatResults <- ComBat(dat=GEN_Data, batch=BatchDataSelected[,batchColName], mod=mod, par.prior=TRUE, prior.plots=FALSE);
   
   #GEN_Data_Corrected=CombatResults[,-1]
   #class(GEN_Data_Corrected) <- "numeric"


### PR DESCRIPTION
When trying to duplicate your processing of the curatedOvarianData, I found that the option numCovs=NULL in the call to the ComBat function was throwing the following error:
Error in ComBat(dat = GEN_Data, batch = BatchDataSelected[, batchColName],  : 
  unused argument (numCovs = NULL)
Removing this argument fixes the problem. This may be a versioning issue (I am using sva version 3.20.0), but I'll leave it up to you to decide.
Thanks!
